### PR TITLE
Add Neo4Reach link and Java section

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated list of awesome open source projects in Jordan or by Jordanians.
 - [Python](#python)
 - [Ruby](#ruby)
 - [Android](#android)
+- [Java](#java)
 
 # Awesome Jordan
 
@@ -47,6 +48,8 @@ A curated list of awesome open source projects in Jordan or by Jordanians.
 ## Android
 * [MDC_LocLookup](https://github.com/NRCMERO/MDC_LocLookup) - Off Line Location Look up.
 
+## Java
+* [Neo4Reach](https://github.com/wael34218/neo4reach) - Reachability index extension for Neo4j graph database.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A curated list of awesome open source projects in Jordan or by Jordanians.
 * [MDC_LocLookup](https://github.com/NRCMERO/MDC_LocLookup) - Off Line Location Look up.
 
 ## Java
-* [Neo4Reach](https://github.com/wael34218/neo4reach) - Reachability index extension for Neo4j graph database.
+* [Neo4Reach](https://github.com/wael34218/neo4reach) - Reachability index extension for Neo4j graph database (inactive).
 
 # Contributing
 


### PR DESCRIPTION
This Neo4j extension allows you to create a reachability index; a data structure that allows users to query whether node A can reach node B in O(1) time. This extension can easily be installed and accessed using HTTP requests. Currently it works perfectly on static graphs, but still needs a lot of work to make it work on dynamic ones. i.e handle node and relation insertion and deletion.

Potentially, the same data structure can be used to create shortest path index.

This work is an implementation of the following paper:
Zhu, Andy Diwen, et al. "Reachability queries on large dynamic graphs: a total order approach." Proceedings of the 2014 ACM SIGMOD international conference on Management of data. ACM, 2014.