### PR TITLE
Add docker-jumpshell, rename docker section to include containers and k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ _Content odered alphabetically_
 * [SenSim](https://github.com/natsheh/sensim) - Sentence Similarity Estimator
 
 
-## Docker
+## Docker, Linux containers and Kubernetes
+* [Docker Jumpshell](https://github.com/muayyad-alsadi/docker-jumpshell) - A secure remote shell access inside docker containers without granting access to host or docker socket
 * [Docker Stanbol Socket.io Server](https://github.com/Vardot/docker-stanbol-nodejs) - A Docker image that installs Apache Stanbol with Socket.IO to provide an HTTP listener for you application with real-time content enhancements.
 
 ## Java


### PR DESCRIPTION
docker jumpshell is a way to grant people access inside running containers, and access their logs using ssh.

it's secure, it uses normal ssh, no access to host, no access to docker socket