### PR TITLE
Added SwarmCD to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ _Content odered alphabetically_
 * [Docker Jumpshell](https://github.com/muayyad-alsadi/docker-jumpshell) - A secure remote shell access inside Docker containers without granting access to host or Docker socket.
 * [Docker Stanbol Socket.io Server](https://github.com/Vardot/docker-stanbol-nodejs) - A Docker image that installs Apache Stanbol with Socket.IO to provide an HTTP listener for your application with real-time content enhancements.
 * [Rancher 2.0 Server Disaster Recovery](https://github.com/Salalem/rancher-s3-backup) - A Docker image that syncs all rancher-data (etcd) to an S3 bucket.
+* [SwarmCD](https://github.com/m-adawi/swarm-cd) - A declarative GitOps and Continuous Deployment tool for Docker Swarm.
 * [wireguard-operator](https://github.com/jodevsa/wireguard-operator) - A wireguard operator created to easily provision a VPN in a k8s cluster.
 
 ## Frontend


### PR DESCRIPTION
This open-source tool follows the GitOps methodology to automates deployments to Docker swarm clusters. Here's how it works: you can store all your Docker compose and config files for your stacks in a git repo. Then, you deploy this tool to your Docker swarm cluster, configure it to use that repo, and it will keep an eye out for any changes, deploying them to the cluster automatically. This way, you won't have to log in to your cluster every time to run some commands. 